### PR TITLE
Remove init dependency on GovernorAlpha

### DIFF
--- a/contracts/GovernorBravoDelegate.sol
+++ b/contracts/GovernorBravoDelegate.sol
@@ -320,11 +320,11 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV1, GovernorBravoE
 
     /**
      * @notice Initiate the GovernorBravo contract
-     * @dev Admin only. Sets initial proposal id which initiates the contract, ensuring a continuous proposal id count
+     * @dev Admin only
      */
-    function _initiate(address governorAlpha) external {
+    function _initiate() external {
         require(msg.sender == admin, "GovernorBravo::_initiate: admin only");
-        require(initialProposalId == 0, "GovernorBravo::_initiate: can only initiate once");
+        require(proposalCount == 0, "GovernorBravo::_initiate: can only initiate once");
         timelock.acceptAdmin();
     }
 

--- a/contracts/GovernorBravoDelegate.sol
+++ b/contracts/GovernorBravoDelegate.sol
@@ -74,8 +74,6 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV1, GovernorBravoE
      * @return Proposal id of new proposal
      */
     function propose(address[] memory targets, uint[] memory values, string[] memory signatures, bytes[] memory calldatas, string memory description) public returns (uint) {
-        // Reject proposals before initiating as Governor
-        require(initialProposalId != 0, "GovernorBravo::propose: Governor Bravo not active");
         require(forth.getPriorVotes(msg.sender, sub256(block.number, 1)) > proposalThreshold, "GovernorBravo::propose: proposer votes below proposal threshold");
         require(targets.length == values.length && targets.length == signatures.length && targets.length == calldatas.length, "GovernorBravo::propose: proposal function information arity mismatch");
         require(targets.length != 0, "GovernorBravo::propose: must provide actions");
@@ -197,7 +195,7 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV1, GovernorBravoE
      * @return Proposal state
      */
     function state(uint proposalId) public view returns (ProposalState) {
-        require(proposalCount >= proposalId && proposalId > initialProposalId, "GovernorBravo::state: invalid proposal id");
+        require(proposalCount >= proposalId && proposalId > 0, "GovernorBravo::state: invalid proposal id");
         Proposal storage proposal = proposals[proposalId];
         if (proposal.canceled) {
             return ProposalState.Canceled;
@@ -323,13 +321,10 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV1, GovernorBravoE
     /**
      * @notice Initiate the GovernorBravo contract
      * @dev Admin only. Sets initial proposal id which initiates the contract, ensuring a continuous proposal id count
-     * @param governorAlpha The address for the Governor to continue the proposal id count from
      */
     function _initiate(address governorAlpha) external {
         require(msg.sender == admin, "GovernorBravo::_initiate: admin only");
         require(initialProposalId == 0, "GovernorBravo::_initiate: can only initiate once");
-        proposalCount = GovernorAlpha(governorAlpha).proposalCount();
-        initialProposalId = proposalCount;
         timelock.acceptAdmin();
     }
 

--- a/contracts/GovernorBravoDelegate.sol
+++ b/contracts/GovernorBravoDelegate.sol
@@ -58,6 +58,7 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV1, GovernorBravoE
         require(proposalThreshold_ >= MIN_PROPOSAL_THRESHOLD && proposalThreshold_ <= MAX_PROPOSAL_THRESHOLD, "GovernorBravo::initialize: invalid proposal threshold");
 
         timelock = TimelockInterface(timelock_);
+        timelock.acceptAdmin();
         forth = ForthInterface(forth_);
         votingPeriod = votingPeriod_;
         votingDelay = votingDelay_;
@@ -316,16 +317,6 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV1, GovernorBravoE
         proposalThreshold = newProposalThreshold;
 
         emit ProposalThresholdSet(oldProposalThreshold, proposalThreshold);
-    }
-
-    /**
-     * @notice Initiate the GovernorBravo contract
-     * @dev Admin only
-     */
-    function _initiate() external {
-        require(msg.sender == admin, "GovernorBravo::_initiate: admin only");
-        require(proposalCount == 0, "GovernorBravo::_initiate: can only initiate once");
-        timelock.acceptAdmin();
     }
 
     /**

--- a/contracts/GovernorBravoInterfaces.sol
+++ b/contracts/GovernorBravoInterfaces.sol
@@ -73,9 +73,6 @@ contract GovernorBravoDelegateStorageV1 is GovernorBravoDelegatorStorage {
     /// @notice The number of votes required in order for a voter to become a proposer
     uint public proposalThreshold;
 
-    /// @notice Initial proposal id set at become
-    uint public initialProposalId;
-
     /// @notice The total number of proposals
     uint public proposalCount;
 
@@ -176,9 +173,4 @@ interface TimelockInterface {
 
 interface ForthInterface {
     function getPriorVotes(address account, uint blockNumber) external view returns (uint96);
-}
-
-interface GovernorAlpha {
-    /// @notice The total number of proposals
-    function proposalCount() external returns (uint);
 }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -14,13 +14,13 @@ interface GovernanceFixture {
 }
 
 export async function governanceFixture(
-    [wallet]: Wallet[],
-    provider: providers.Web3Provider
+  [wallet]: Wallet[],
+  provider: providers.Web3Provider
 ): Promise<GovernanceFixture> {
-    // deploy FORTH, sending the total supply to the deployer
-    const { timestamp: now } = await provider.getBlock('latest')
-    const timelockAddress = Contract.getContractAddress({ from: wallet.address, nonce: 1 })
-    const forth = await deployContract(wallet, Forth, [wallet.address, timelockAddress, now + 60 * 60])
+  // deploy FORTH, sending the total supply to the deployer
+  const { timestamp: now } = await provider.getBlock('latest')
+  const timelockAddress = Contract.getContractAddress({ from: wallet.address, nonce: 1 })
+  const forth = await deployContract(wallet, Forth, [wallet.address, timelockAddress, now + 60 * 60])
 
   return { forth }
 }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -14,13 +14,13 @@ interface GovernanceFixture {
 }
 
 export async function governanceFixture(
-  [wallet]: Wallet[],
-  provider: providers.Web3Provider
+    [wallet]: Wallet[],
+    provider: providers.Web3Provider
 ): Promise<GovernanceFixture> {
-  // deploy FORTH, sending the total supply to the deployer
-  const { timestamp: now } = await provider.getBlock('latest')
-  const timelockAddress = Contract.getContractAddress({ from: wallet.address, nonce: 1 })
-  const forth = await deployContract(wallet, Forth, [wallet.address, timelockAddress, now + 60 * 60])
+    // deploy FORTH, sending the total supply to the deployer
+    const { timestamp: now } = await provider.getBlock('latest')
+    const timelockAddress = Contract.getContractAddress({ from: wallet.address, nonce: 1 })
+    const forth = await deployContract(wallet, Forth, [wallet.address, timelockAddress, now + 60 * 60])
 
   return { forth }
 }


### PR DESCRIPTION
GovernorBravo's initialization sets the proposal ids to start after GovernorAlpha's.
In our case, we want it to start with a clean slate w/ first proposal having id = 1